### PR TITLE
Add x-checker-data for automatic update checks

### DIFF
--- a/studio.eufonia.EufoniaClient.yml
+++ b/studio.eufonia.EufoniaClient.yml
@@ -65,6 +65,12 @@ modules:
         dest-filename: Eufonia-Client.deb
         sha256: e3f8477ebbfb8a5b262301ea748caae9fa74c4c0d78bff51bbc56678296f16bb
         only-arches: [x86_64] #This source is only used on x86_64 Computers
+        x-checker-data:
+          type: json
+          url: https://client.eufonia.studio/api/v2/update/latest?platform=debian-x86_64
+          version-query: .version
+          url-query: .url
+          is-main-source: true
     build-commands:
       - ar -x Eufonia-Client.deb
       - tar -xf data.tar.gz


### PR DESCRIPTION
This PR adds support to the Flathub bot to update the main source automatically by doing a query to the Eufonia update API.